### PR TITLE
Fixing a bug that occurs when proxying crossdomain requests

### DIFF
--- a/src/directives/proxy.ts
+++ b/src/directives/proxy.ts
@@ -37,6 +37,9 @@ export function getProxyDirective(args: GraphQLArgument[]) {
     // Setting content-length may cause problem in proxy
     delete (options.headers as any)['content-length']
 
+    // The incoming host is reset to be able to send cross-domain requests
+    delete (options.headers as any)['host']
+
     options.body = args
     return rp(options)
   }


### PR DESCRIPTION
## The problem

Unable to send request from graphql-rest-proxy to rest-api on another domain.

## The reason

The host parameter value is taken from the proxy request. This can be seen [here](https://github.com/acro5piano/graphql-rest-proxy/blob/v0.4.1/src/directives/proxy.ts#L33).

This behavior is incorrect because the `host` header must contain the name of the domain for which the request is intended.

## Solution

It is necessary to reset the original `host` value to send a request in rest api.

## Before fix

#### Request

```
{
    uri: 'https: //rest-api.loc.dev/v1/mail/subscribe?access-token=test',
    method: 'post',
    headers: {
        host: 'graphql-rest-proxy.loc.dev', <---- Here is the problem: Host incorrect
        connection: 'close',
        'x-real-ip': '192.168.160.1',
        'x-forwarded-for': '192.168.160.1',
        'x-forwarded-proto': 'https',
        'x-forwarded-ssl': 'on',
        'x-forwarded-port': '443',
        'content-type': 'application/json',
        'user-agent': 'PostmanRuntime/7.22.0',
        accept: '*/*',
        'cache-control': 'no-cache',
        'accept-encoding': 'gzip, deflate, br',
        'User-Agent': 'graphql-rest-proxy'
    },
    body: {
        arg: {
            email: 'subscriber@test.com',
        }
    },
    json: true
}
```

#### Response

First error: Certificate issues because `host` is invalid.

```
{
    "errors": [
        {
            "message": "Error: unable to verify the first certificate",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "subscribe"
            ]
        }
    ],
    "data": {
        "subscribe": null
    }
}
```

Second error: Page not found.

Trying to ignore certificate issues by set `NODE_TLS_REJECT_UNAUTHORIZED` env to `0`

```
{
    "errors": [
        {
            "message": "404 - Page not found",
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "path": [
                "subscribe"
            ]
        }
    ],
    "data": {
        "subscribe": null
    }
}
```

## After fix

#### Request

```
{
    uri: 'https: //rest-api.loc.dev/v1/mail/subscribe?access-token=test',
    method: 'post',
    headers: {
        host: 'rest-api.loc.dev', <---- Correct host value
        connection: 'close',
        'x-real-ip': '192.168.160.1',
        'x-forwarded-for': '192.168.160.1',
        'x-forwarded-proto': 'https',
        'x-forwarded-ssl': 'on',
        'x-forwarded-port': '443',
        'content-type': 'application/json',
        'user-agent': 'PostmanRuntime/7.22.0',
        accept: '*/*',
        'cache-control': 'no-cache',
        'accept-encoding': 'gzip, deflate, br',
        'User-Agent': 'graphql-rest-proxy'
    },
    body: {
        arg: {
            email: 'subscriber@test.com',
        }
    },
    json: true
}
```

#### Response

```
{
    "data": {
        "subscribe": {
            "code": 202,
            "message": "Success"
        }
    }
}
```

## Result

The fix solves both of the above problems 🚀.

_P.S. Grateful for a very useful library!_