### PR TITLE
allow to interpolate at any position in the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ type Query {
 
 **Query with Parameters**
 
-You can refer the id of query args by `$id`.
+You can refer the id of query args by `^id`.
 
 ```graphql
 type User {
@@ -106,7 +106,7 @@ type User {
 }
 
 type Query {
-  getUserById(id: Int!): User @proxy(get: "https://my-rest-api.com/users/$id")
+  getUserById(id: Int!): User @proxy(get: "https://my-rest-api.com/users/^id")
 }
 ```
 
@@ -126,7 +126,7 @@ type User {
 
 type Mutation {
   createUser(user: UserInput!): User @proxy(post: "https://my-rest-api.com/users")
-  updateUser(id: Int!, user: UserInput!): User @proxy(patch: "https://my-rest-api.com/users/$id")
+  updateUser(id: Int!, user: UserInput!): User @proxy(patch: "https://my-rest-api.com/users/^id")
 }
 ```
 
@@ -159,7 +159,7 @@ fetch('http://localhost:5252/graphql', {
 
 **Nested Objects**
 
-You can refer the id of parent object by `$id`.
+You can refer the id of parent object by `^id`.
 
 ```graphql
 type Post {
@@ -170,7 +170,7 @@ type Post {
 type User {
   id: Int
   name: String
-  posts: [Post] @proxy(get: "https://my-rest-api.com/users/$id/posts")
+  posts: [Post] @proxy(get: "https://my-rest-api.com/users/^id/posts")
 }
 
 type Query {
@@ -245,7 +245,7 @@ type Post {
 type User {
   id: Int
   name: String
-  posts: [Post] @proxy(get: "https://my-rest-api.com/users/$id/posts")
+  posts: [Post] @proxy(get: "https://my-rest-api.com/users/^id/posts")
 }
 
 type Query {

--- a/examples/schema.graphql
+++ b/examples/schema.graphql
@@ -19,5 +19,5 @@ type Query {
 
 type Mutation {
   createUser(user: UserInput): User @proxy(post: "/users")
-  updateUser(id: Int!, user: UserInput!): User @proxy(patch: "/users")
+  updateUser(id: Int!, name: String!): User @proxy(patch: "/users/^id")
 }

--- a/src/directives/proxy.ts
+++ b/src/directives/proxy.ts
@@ -50,13 +50,22 @@ function buildUri(uri: string, parent?: any, args?: any) {
 
   const parentWithArgs = Object.assign(parent, args);
   if (parentWithArgs) {
-      let temparr = builtUri.split('/');
-      temparr.forEach((item, index) => {
-          if (item.includes('$')) {
-              temparr[index] = String(parentWithArgs[item.replace('$', '')]);
-          }
-      });
-      builtUri = temparr.join('/');
+    // Legacy way to replace $param in the uri
+    let temparr = builtUri.split('/');
+    temparr.forEach((item, index) => {
+      if (item.includes('$')) {
+        temparr[index] = String(parentWithArgs[item.replace('$', '')]);
+      }
+    });
+    builtUri = temparr.join('/');
+
+    // New way to replace ^param in the uri
+    Object.keys(parentWithArgs).forEach(key => {
+      builtUri = builtUri.replace(
+        new RegExp(`\\^${key}`, 'g'),
+        encodeURIComponent(String(parentWithArgs[key]))
+      );
+    });
   }
 
   if (builtUri.startsWith('http')) {

--- a/tests/mock-server.ts
+++ b/tests/mock-server.ts
@@ -12,11 +12,11 @@ app.use((req, _res, next) => {
   next()
 })
 
-const userMock = {
-  id: 1,
+let userMock = (id: unknown = 1) => ({
+  id,
   name: 'Kazuya',
   isActive: true,
-}
+})
 
 const postMock = {
   id: 1,
@@ -24,19 +24,19 @@ const postMock = {
 }
 
 app.get('/user', (_req, res) => {
-  res.send(userMock)
+  res.send(userMock())
 })
 
 app.get('/users/:id', (_req, res) => {
-  res.send(userMock)
+  res.send(userMock(_req.params.id))
 })
 
 app.get('/user_with_posts', (_req, res) => {
-  res.send({ ...userMock, posts: [postMock] })
+  res.send({ ...userMock(), posts: [postMock] })
 })
 
 app.get('/users', (_req, res) => {
-  res.send([userMock, userMock])
+  res.send([userMock(), userMock()])
 })
 
 app.get('/users/:id/posts', (_req, res) => {
@@ -44,15 +44,15 @@ app.get('/users/:id/posts', (_req, res) => {
 })
 
 app.post('/users', (_req, res) => {
-  res.send(userMock)
+  res.send(userMock())
 })
 
 app.patch('/users/:id', (_req, res) => {
-  res.send(userMock)
+  res.send(userMock(_req.params.id))
 })
 
 app.put('/users/:id', (_req, res) => {
-  res.send(userMock)
+  res.send(userMock(_req.params.id))
 })
 
 let server: any

--- a/tests/query-with-param.test.ts
+++ b/tests/query-with-param.test.ts
@@ -1,0 +1,69 @@
+import request from 'supertest'
+import { server } from '../src'
+import { gql, prepareTestWithSchema } from './test-utils'
+import { terminate } from './mock-server'
+import test from 'ava'
+
+test.before(async () => {
+  await prepareTestWithSchema(gql`
+    type User {
+      id: String
+      name: String
+    }
+
+    type Query {
+      getUserById(id: Int!): User @proxy(get: "http://localhost:PORT/users/prefix^idsuffix")
+      legacyGetUserById(id: Int!): User @proxy(get: "http://localhost:PORT/users/prefix$idsuffix")
+    }
+  `)
+})
+
+test.after(terminate)
+
+test('can get', async (t) => {
+  let res = await request(server)
+    .post('/graphql')
+    .send({
+      query: gql`
+        query GetUser {
+          getUserById(id: 1) {
+            id
+            name
+          }
+        }
+      `,
+    })
+    .expect(200)
+  t.deepEqual(res.body, {
+    data: {
+      getUserById: {
+        id: `prefix1suffix`,
+        name: 'Kazuya',
+      },
+    },
+  })
+})
+
+test('legacy does not replace $param in the uri', async (t) => {
+  let res = await request(server)
+    .post('/graphql')
+    .send({
+      query: gql`
+        query GetUser {
+          legacyGetUserById(id: 1) {
+            id
+            name
+          }
+        }
+      `,
+    })
+    .expect(200)
+  t.deepEqual(res.body, {
+    data: {
+      legacyGetUserById: {
+        id: `undefined`,
+        name: 'Kazuya',
+      },
+    },
+  })
+})


### PR DESCRIPTION
## Description
This PR extends the URL interpolation logic:
- Adds support for a new `^param` syntax that can be replaced anywhere in the URL string.  
- Keeps support for the legacy `$param` syntax.  
- Values are properly URL-encoded during replacement.  

## Use case
When building dynamic requests, it’s useful to interpolate parameters at any position in the URL (not just path segments), for example, for dynamic (sub)domains.

```graphql
aQuery(subdomain: String!): ReturnType @proxy(patch: "https://^subdomain.domain.com/ping")
```

## Checklist
- [x] Tests done

## Discussion

- **Why `^` and not `$`?**

  According to the URL spec, `^` is a forbidden character, while `$` is not. Thus, we are sure that it will never try to replace values that should **not** be replaced.
  
- **Should we remove the "legacy" interpolation method?**

  To prevent from breaking changes, I decided to keep it, but maybe it is better to remove it if this PR is accepted?

_I am open to discuss about any alternative solution for this use case._